### PR TITLE
Brighten rotating text and square blog cards

### DIFF
--- a/src/components/BlogCarousel.css
+++ b/src/components/BlogCarousel.css
@@ -7,10 +7,10 @@
 
 .blog-carousel__viewport {
   overflow: hidden;
-  border-radius: 26px;
-  border: 1px solid rgba(61, 218, 215, 0.15);
-  background: rgba(255, 255, 255, 0.9);
-  box-shadow: inset 0 0 0 1px rgba(248, 250, 180, 0.14);
+  border-radius: 18px;
+  border: 1px solid rgba(255, 0, 92, 0.22);
+  background: var(--surface-strong);
+  box-shadow: inset 0 0 0 1px rgba(255, 246, 0, 0.12);
   cursor: grab;
 }
 
@@ -26,15 +26,18 @@
 }
 
 .blog-card {
-  min-width: min(320px, 80vw);
+  width: clamp(260px, 28vw, 320px);
+  min-height: clamp(260px, 28vw, 320px);
   scroll-snap-align: start;
   flex: 0 0 auto;
   padding: clamp(1.6rem, 4vw, 2.2rem);
-  border-radius: 20px;
-  background: rgba(255, 255, 255, 0.95);
-  border: 1px solid rgba(248, 250, 180, 0.3);
-  box-shadow: 0 24px 36px rgba(15, 39, 37, 0.08);
+  border-radius: 16px;
+  background: rgba(16, 16, 16, 0.92);
+  border: 1px solid rgba(255, 0, 92, 0.2);
+  box-shadow: 0 24px 36px rgba(0, 0, 0, 0.55);
   display: grid;
+  grid-template-rows: auto 1fr auto;
+  align-content: start;
   gap: 0.85rem;
 }
 
@@ -45,13 +48,13 @@
 
 .blog-card p {
   margin: 0;
-  color: rgba(15, 39, 37, 0.72);
+  color: rgba(246, 239, 210, 0.78);
 }
 
 .blog-card__link {
   font-weight: 600;
   font-size: 0.95rem;
-  color: var(--accent-rose);
+  color: var(--accent-butter);
 }
 
 .blog-carousel__control {
@@ -59,24 +62,24 @@
   height: 48px;
   border-radius: 50%;
   border: none;
-  background: radial-gradient(circle at 30% 30%, rgba(61, 218, 215, 0.28), rgba(240, 135, 135, 0.35));
-  color: var(--ink);
+  background: var(--accent-rose);
+  color: #0a0a0a;
   font-size: 1.8rem;
   line-height: 1;
   display: grid;
   place-items: center;
   cursor: pointer;
   transition: transform 240ms ease, box-shadow 240ms ease;
-  box-shadow: 0 14px 24px rgba(240, 135, 135, 0.26);
+  box-shadow: 0 14px 24px rgba(247, 56, 89, 0.35);
 }
 
 .blog-carousel__control:hover {
   transform: translateY(-3px);
-  box-shadow: 0 18px 32px rgba(240, 135, 135, 0.34);
+  box-shadow: 0 18px 32px rgba(247, 56, 89, 0.45);
 }
 
 .blog-carousel__control:focus-visible {
-  outline: 2px solid var(--accent-aqua);
+  outline: 2px solid var(--accent-butter);
   outline-offset: 3px;
 }
 

--- a/src/components/LiquidBackground.css
+++ b/src/components/LiquidBackground.css
@@ -4,7 +4,7 @@
   overflow: hidden;
   pointer-events: none;
   z-index: 0;
-  background: #ffffff;
+  background: #000000;
   --pointer-x: 50%;
   --pointer-y: 50%;
 }
@@ -19,21 +19,21 @@
   filter: blur(100px);
   opacity: 0.8;
   transition: opacity 400ms ease;
-  mix-blend-mode: multiply;
+  mix-blend-mode: screen;
   animation: liquid-oscillate 18s ease-in-out infinite;
 }
 
 .liquid-ether__layer--a {
-  background: radial-gradient(circle at center, rgba(61, 218, 215, 0.32), transparent 65%);
+  background: radial-gradient(circle at center, rgba(255, 0, 92, 0.32), transparent 65%);
 }
 
 .liquid-ether__layer--b {
-  background: radial-gradient(circle at center, rgba(240, 135, 135, 0.25), transparent 60%);
+  background: radial-gradient(circle at center, rgba(255, 246, 0, 0.24), transparent 60%);
   animation-delay: -6s;
 }
 
 .liquid-ether__layer--c {
-  background: radial-gradient(circle at center, rgba(248, 250, 180, 0.22), transparent 62%);
+  background: radial-gradient(circle at center, rgba(247, 56, 89, 0.26), transparent 62%);
   animation-delay: -12s;
 }
 

--- a/src/components/RotatingText.css
+++ b/src/components/RotatingText.css
@@ -5,7 +5,7 @@
   justify-items: center;
   min-width: 14ch;
   font-weight: 600;
-  color: #0f2725;
+  color: var(--accent-butter);
   text-transform: lowercase;
 }
 
@@ -17,8 +17,8 @@
   width: 100%;
   padding: 0.2rem 0.6rem 0.3rem;
   border-radius: 0.75rem;
-  background: rgba(61, 218, 215, 0.14);
-  color: #0f2725;
+  background: rgba(255, 246, 0, 0.65);
+  color: #ffffff;
   opacity: 0;
   transform: translateY(12px) rotate(2deg);
   filter: blur(6px);
@@ -29,7 +29,7 @@
   opacity: 1;
   transform: translateY(0) rotate(0deg);
   filter: blur(0);
-  background: rgba(240, 135, 135, 0.2);
+  background: var(--accent-aqua);
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/components/ScrollStack.css
+++ b/src/components/ScrollStack.css
@@ -9,7 +9,7 @@
   content: '';
   position: absolute;
   inset: 0;
-  background: linear-gradient(180deg, rgba(248, 250, 180, 0.16), transparent 35%, transparent 65%, rgba(61, 218, 215, 0.1));
+  background: linear-gradient(180deg, rgba(255, 0, 92, 0.08), transparent 35%, transparent 65%, rgba(255, 246, 0, 0.08));
   pointer-events: none;
   z-index: -2;
 }
@@ -19,9 +19,9 @@
   top: calc(clamp(5rem, 18vh, 8rem) + var(--stack-index, 0) * clamp(0.8rem, 2vw, 1.4rem));
   padding: clamp(2rem, 5vw, 2.8rem);
   border-radius: 26px;
-  border: 1px solid rgba(61, 218, 215, 0.2);
-  background: rgba(255, 255, 255, 0.95);
-  box-shadow: 0 28px 60px rgba(15, 39, 37, 0.12);
+  border: 1px solid rgba(255, 0, 92, 0.24);
+  background: linear-gradient(155deg, rgba(228, 54, 54, 0.32), rgba(18, 18, 18, 0.97));
+  box-shadow: 0 28px 60px rgba(0, 0, 0, 0.62);
   display: grid;
   gap: 1.1rem;
   overflow: hidden;
@@ -54,18 +54,18 @@
   font-weight: 600;
   letter-spacing: 0.18em;
   text-transform: uppercase;
-  color: rgba(15, 39, 37, 0.8);
-  background: linear-gradient(135deg, rgba(61, 218, 215, 0.18), rgba(240, 135, 135, 0.25));
-  box-shadow: inset 0 0 0 1px rgba(61, 218, 215, 0.2);
+  color: #080808;
+  background: linear-gradient(135deg, rgba(255, 246, 0, 0.35), rgba(255, 0, 92, 0.45));
+  box-shadow: inset 0 0 0 1px rgba(255, 0, 92, 0.28);
 }
 
 .scroll-stack__titles p {
-  color: rgba(15, 39, 37, 0.65);
+  color: rgba(246, 239, 210, 0.7);
   font-size: 0.95rem;
 }
 
 .scroll-stack__description {
-  color: rgba(15, 39, 37, 0.72);
+  color: rgba(246, 239, 210, 0.78);
   font-size: 1.02rem;
 }
 
@@ -74,16 +74,16 @@
   padding-left: 1.1rem;
   display: grid;
   gap: 0.45rem;
-  color: rgba(15, 39, 37, 0.7);
+  color: rgba(246, 239, 210, 0.75);
   font-size: 0.95rem;
 }
 
 .scroll-stack__glow {
   position: absolute;
   inset: -35% -40% 40% -40%;
-  background: radial-gradient(circle at 20% 20%, rgba(61, 218, 215, 0.32), transparent 65%),
-    radial-gradient(circle at 80% 80%, rgba(240, 135, 135, 0.35), transparent 65%),
-    radial-gradient(circle at 50% 0%, rgba(255, 199, 167, 0.4), transparent 70%);
+  background: radial-gradient(circle at 20% 20%, rgba(255, 0, 92, 0.35), transparent 65%),
+    radial-gradient(circle at 80% 80%, rgba(255, 246, 0, 0.25), transparent 70%),
+    radial-gradient(circle at 50% 0%, rgba(247, 56, 89, 0.4), transparent 70%);
   filter: blur(70px);
   opacity: 0.9;
   z-index: -1;

--- a/src/index.css
+++ b/src/index.css
@@ -2,16 +2,19 @@
 
 :root {
   font-family: 'Space Grotesk', 'Plus Jakarta Sans', 'Segoe UI', sans-serif;
-  color: #152221;
-  background-color: #ffffff;
+  color: #f6efd2;
+  background-color: #000000;
   line-height: 1.6;
-  --accent-aqua: #3ddad7;
-  --accent-rose: #f08787;
-  --accent-peach: #ffc7a7;
-  --accent-butter: #f8fab4;
-  --ink: #0f2725;
-  --muted: #5f7573;
-  --border: #e4eeed;
+  --accent-aqua: #ff005c;
+  --accent-rose: #f73859;
+  --accent-peach: #e43636;
+  --accent-butter: #fff600;
+  --ink: #f6efd2;
+  --muted: rgba(230, 221, 180, 0.7);
+  --border: rgba(246, 239, 210, 0.16);
+  --surface: rgba(12, 12, 12, 0.86);
+  --surface-strong: rgba(20, 20, 20, 0.94);
+  --shadow: 0 40px 80px rgba(0, 0, 0, 0.65);
   --sticky-header-offset: clamp(6.5rem, 14vw, 9rem);
 }
 
@@ -22,7 +25,7 @@
 body {
   margin: 0;
   min-height: 100vh;
-  background: #ffffff;
+  background: #000000;
   color: var(--ink);
   -webkit-font-smoothing: antialiased;
 }
@@ -37,7 +40,7 @@ a {
 }
 
 a:focus-visible {
-  outline: 2px solid var(--accent-aqua);
+  outline: 2px solid var(--accent-butter);
   outline-offset: 2px;
 }
 
@@ -53,8 +56,9 @@ a:focus-visible {
   position: sticky;
   top: 0;
   z-index: 3;
-  background: #ffffff;
+  background: var(--surface);
   border-bottom: 1px solid var(--border);
+  backdrop-filter: blur(14px);
 }
 
 .page__header-inner {
@@ -72,7 +76,7 @@ a:focus-visible {
   font-weight: 600;
   letter-spacing: 0.18em;
   text-transform: uppercase;
-  color: var(--muted);
+  color: var(--accent-butter);
 }
 
 .page__nav {
@@ -87,7 +91,7 @@ a:focus-visible {
   font-weight: 500;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: var(--ink);
+  color: rgba(246, 239, 210, 0.82);
   transition: color 320ms ease;
 }
 
@@ -97,8 +101,8 @@ a:focus-visible {
   inset: auto 0 -0.55rem 0;
   height: 0.3rem;
   border-radius: 999px;
-  background: radial-gradient(circle at 20% 20%, rgba(61, 218, 215, 0.45), transparent 70%),
-    radial-gradient(circle at 80% 80%, rgba(240, 135, 135, 0.4), transparent 70%);
+  background: radial-gradient(circle at 20% 20%, rgba(255, 246, 0, 0.6), transparent 70%),
+    radial-gradient(circle at 80% 80%, rgba(255, 0, 92, 0.45), transparent 70%);
   opacity: 0;
   transform: scaleX(0.4);
   transition: opacity 320ms ease, transform 320ms ease;
@@ -106,7 +110,7 @@ a:focus-visible {
 
 .page__nav a:hover,
 .page__nav a:focus-visible {
-  color: var(--muted);
+  color: var(--accent-butter);
 }
 
 .page__nav a:hover::after,
@@ -145,7 +149,7 @@ a:focus-visible {
   font-size: 0.85rem;
   letter-spacing: 0.32em;
   text-transform: uppercase;
-  color: rgba(15, 39, 37, 0.58);
+  color: rgba(246, 239, 210, 0.58);
 }
 
 .section__title {
@@ -158,7 +162,7 @@ a:focus-visible {
 .section__subtitle {
   margin: 0;
   font-family: 'Plus Jakarta Sans', 'Space Grotesk', sans-serif;
-  color: rgba(15, 39, 37, 0.68);
+  color: rgba(246, 239, 210, 0.7);
 }
 
 .services__manifesto {
@@ -166,7 +170,7 @@ a:focus-visible {
   max-width: 820px;
   font-size: clamp(1.05rem, 2.6vw, 1.2rem);
   line-height: 1.65;
-  color: rgba(15, 39, 37, 0.78);
+  color: rgba(246, 239, 210, 0.82);
   font-weight: 500;
   letter-spacing: -0.01em;
 }
@@ -176,7 +180,7 @@ a:focus-visible {
   max-width: 780px;
   font-size: clamp(1.02rem, 2.4vw, 1.18rem);
   line-height: 1.6;
-  color: rgba(15, 39, 37, 0.78);
+  color: rgba(246, 239, 210, 0.82);
 }
 
 .hero {
@@ -190,9 +194,9 @@ a:focus-visible {
   max-width: clamp(520px, 60vw, 680px);
   padding: clamp(2.6rem, 6vw, 4rem);
   border-radius: 28px;
-  background: rgba(255, 255, 255, 0.88);
-  border: 1px solid rgba(61, 218, 215, 0.25);
-  box-shadow: 0 40px 80px rgba(15, 39, 37, 0.08);
+  background: linear-gradient(140deg, rgba(255, 0, 92, 0.16), rgba(14, 14, 14, 0.92));
+  border: 1px solid rgba(255, 246, 0, 0.22);
+  box-shadow: var(--shadow);
   display: grid;
   gap: 1.5rem;
   text-align: center;
@@ -204,7 +208,7 @@ a:focus-visible {
   font-size: 0.95rem;
   letter-spacing: 0.28em;
   text-transform: uppercase;
-  color: rgba(15, 39, 37, 0.6);
+  color: rgba(255, 246, 0, 0.7);
 }
 
 .hero__heading {
@@ -224,7 +228,7 @@ a:focus-visible {
   margin: 0;
   font-family: 'Plus Jakarta Sans', 'Space Grotesk', sans-serif;
   font-size: 1rem;
-  color: rgba(15, 39, 37, 0.72);
+  color: rgba(246, 239, 210, 0.78);
   max-width: 34ch;
 }
 
@@ -232,7 +236,7 @@ a:focus-visible {
   display: grid;
   gap: 1.2rem;
   font-size: 1.05rem;
-  color: rgba(15, 39, 37, 0.8);
+  color: rgba(246, 239, 210, 0.82);
 }
 
 
@@ -240,9 +244,9 @@ a:focus-visible {
   position: relative;
   padding: clamp(1.8rem, 4vw, 2.4rem);
   border-radius: 22px;
-  border: 1px solid rgba(240, 135, 135, 0.25);
-  background: rgba(255, 255, 255, 0.92);
-  box-shadow: 0 28px 44px rgba(15, 39, 37, 0.08);
+  border: 1px solid rgba(255, 0, 92, 0.26);
+  background: linear-gradient(150deg, rgba(231, 54, 89, 0.16), rgba(16, 16, 16, 0.94));
+  box-shadow: 0 28px 44px rgba(0, 0, 0, 0.6);
   display: grid;
   gap: 0.8rem;
   transition: transform 360ms ease;
@@ -256,11 +260,11 @@ a:focus-visible {
   justify-self: flex-start;
   padding: 0.25rem 0.75rem;
   border-radius: 999px;
-  background: rgba(61, 218, 215, 0.16);
+  background: linear-gradient(135deg, rgba(255, 246, 0, 0.28), rgba(255, 0, 92, 0.38));
   font-size: 0.75rem;
   letter-spacing: 0.18em;
   text-transform: uppercase;
-  color: rgba(15, 39, 37, 0.65);
+  color: #080808;
 }
 
 .contact__panel {
@@ -269,9 +273,9 @@ a:focus-visible {
   gap: clamp(2rem, 4vw, 3rem);
   padding: clamp(2.6rem, 6vw, 3.5rem);
   border-radius: 28px;
-  background: rgba(255, 255, 255, 0.92);
-  border: 1px solid rgba(61, 218, 215, 0.25);
-  box-shadow: 0 32px 60px rgba(15, 39, 37, 0.1);
+  background: var(--surface-strong);
+  border: 1px solid rgba(255, 0, 92, 0.24);
+  box-shadow: 0 32px 60px rgba(0, 0, 0, 0.65);
 }
 
 .contact__intro {
@@ -285,7 +289,7 @@ a:focus-visible {
   font-size: 0.85rem;
   letter-spacing: 0.28em;
   text-transform: uppercase;
-  color: rgba(15, 39, 37, 0.58);
+  color: rgba(255, 246, 0, 0.7);
 }
 
 .contact__title {
@@ -298,7 +302,7 @@ a:focus-visible {
   margin: 0;
   font-family: 'Plus Jakarta Sans', 'Space Grotesk', sans-serif;
   font-size: 1rem;
-  color: rgba(15, 39, 37, 0.68);
+  color: rgba(246, 239, 210, 0.72);
 }
 
 .contact__form {
@@ -310,7 +314,7 @@ a:focus-visible {
   font-size: 0.9rem;
   letter-spacing: 0.05em;
   text-transform: uppercase;
-  color: rgba(15, 39, 37, 0.6);
+  color: rgba(246, 239, 210, 0.65);
 }
 
 .contact__form input,
@@ -318,8 +322,8 @@ a:focus-visible {
   width: 100%;
   padding: 0.85rem 1rem;
   border-radius: 14px;
-  border: 1px solid rgba(21, 34, 33, 0.12);
-  background: rgba(248, 250, 180, 0.16);
+  border: 1px solid rgba(255, 246, 0, 0.18);
+  background: rgba(20, 20, 20, 0.8);
   font-family: inherit;
   font-size: 1rem;
   color: var(--ink);
@@ -329,8 +333,8 @@ a:focus-visible {
 .contact__form input:focus,
 .contact__form textarea:focus {
   outline: none;
-  border-color: rgba(61, 218, 215, 0.7);
-  box-shadow: 0 0 0 3px rgba(61, 218, 215, 0.18);
+  border-color: rgba(255, 0, 92, 0.7);
+  box-shadow: 0 0 0 3px rgba(255, 0, 92, 0.22);
 }
 
 .contact__form textarea {
@@ -348,17 +352,16 @@ a:focus-visible {
   font-weight: 600;
   letter-spacing: 0.12em;
   text-transform: uppercase;
-  color: #ffffff;
-  background: radial-gradient(circle at 20% 20%, var(--accent-aqua), rgba(61, 218, 215, 0.6)),
-    radial-gradient(circle at 80% 80%, var(--accent-rose), rgba(240, 135, 135, 0.7));
-  box-shadow: 0 18px 30px rgba(240, 135, 135, 0.32);
+  color: #080808;
+  background: var(--accent-butter);
+  box-shadow: 0 18px 30px rgba(255, 246, 0, 0.28);
   cursor: pointer;
   transition: transform 320ms ease, box-shadow 320ms ease;
 }
 
 .contact__submit:hover {
   transform: translateY(-4px);
-  box-shadow: 0 26px 44px rgba(240, 135, 135, 0.4);
+  box-shadow: 0 26px 44px rgba(255, 246, 0, 0.35);
 }
 
 @media (max-width: 720px) {
@@ -404,7 +407,7 @@ a:focus-visible {
   margin-top: auto;
   position: sticky;
   bottom: 0;
-  background: rgba(255, 255, 255, 0.98);
+  background: var(--surface);
   border-top: 1px solid var(--border);
   z-index: 2;
 }
@@ -425,7 +428,7 @@ a:focus-visible {
   font-size: 0.85rem;
   letter-spacing: 0.12em;
   text-transform: uppercase;
-  color: rgba(15, 39, 37, 0.58);
+  color: rgba(246, 239, 210, 0.58);
 }
 
 .page__footer-nav {
@@ -438,11 +441,11 @@ a:focus-visible {
 }
 
 .page__footer-nav a {
-  color: rgba(15, 39, 37, 0.68);
+  color: rgba(246, 239, 210, 0.7);
   transition: color 220ms ease;
 }
 
 .page__footer-nav a:hover,
 .page__footer-nav a:focus-visible {
-  color: var(--ink);
+  color: var(--accent-butter);
 }


### PR DESCRIPTION
## Summary
- restyled the global layout with a black base background and neon accent palette to match the requested colors
- updated hero, contact, and work sections with gradient surfaces, refreshed typography contrast, and consistent highlight treatments
- rethemed supporting components like the liquid background, rotating text, scroll stack, and blog carousel to the new color system
- brightened the rotating text pill, solidified button fills, opacified scroll stack cards, and squared up blog carousel tiles per follow-up feedback

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e26e093460832494d8a52d8f25549a