### PR TITLE
Add backend API service for content management

### DIFF
--- a/backend/.eslintrc.json
+++ b/backend/.eslintrc.json
@@ -1,0 +1,13 @@
+{
+  "env": {
+    "node": true,
+    "es2022": true
+  },
+  "extends": ["eslint:recommended", "prettier"],
+  "parserOptions": {
+    "sourceType": "module"
+  },
+  "rules": {
+    "no-unused-vars": ["warn", { "argsIgnorePattern": "^_" }]
+  }
+}

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,10 @@
+node_modules
+.env
+uploads
+data/database.json
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+package-lock.json
+.DS_Store

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,91 @@
+# Imagicity Backend
+
+A standalone Node.js + Express API designed to power the Imagicity front-end. The service
+focuses on three domains: blogs, services (for the stack menu), and work showcases with
+support for multiple images.
+
+## Features
+
+- **Blogs** – Create, list, update, and delete blog posts. Each post supports an optional
+  cover image and rich content body.
+- **Services** – Manage the services that populate the stack menu, including detailed
+  descriptions and highlight callouts.
+- **Works** – Upload project case studies with multi-image galleries, descriptive copy,
+  and optional client metadata.
+- **File uploads** – Image uploads are stored locally under `/uploads` with static hosting
+  enabled for retrieval.
+- **Validation & Security** – Payloads are validated with Joi, Helmet hardens HTTP headers,
+  and CORS is enabled for easy integration with the existing front-end.
+
+## Getting Started
+
+```bash
+cd backend
+npm install
+npm run dev
+```
+
+The API listens on port `5000` by default. Use the `PORT` environment variable to override
+when deploying to AWS Elastic Beanstalk or another platform.
+
+### Environment Variables
+
+Create a `.env` file if you need to customise the runtime:
+
+```
+PORT=8080
+```
+
+Additional configuration (database URLs, CDN buckets, etc.) can be layered in as the
+project evolves.
+
+## API Overview
+
+### Blogs
+
+| Method | Endpoint        | Description                 |
+| ------ | --------------- | --------------------------- |
+| GET    | `/api/blogs`    | List all blog posts         |
+| GET    | `/api/blogs/:id`| Retrieve a single post      |
+| POST   | `/api/blogs`    | Create a post (supports `multipart/form-data` with `image`) |
+| PUT    | `/api/blogs/:id`| Update a post and optionally replace its image |
+| DELETE | `/api/blogs/:id`| Remove a post and its image |
+
+### Services
+
+| Method | Endpoint           | Description              |
+| ------ | ------------------ | ------------------------ |
+| GET    | `/api/services`    | List available services  |
+| GET    | `/api/services/:id`| Retrieve a service entry |
+| POST   | `/api/services`    | Create a new service     |
+| PUT    | `/api/services/:id`| Update a service         |
+| DELETE | `/api/services/:id`| Remove a service         |
+
+### Works
+
+| Method | Endpoint        | Description                                                          |
+| ------ | --------------- | -------------------------------------------------------------------- |
+| GET    | `/api/works`    | List all works                                                       |
+| GET    | `/api/works/:id`| Retrieve a single work entry                                         |
+| POST   | `/api/works`    | Create a work entry (use `multipart/form-data` with `images[]`)      |
+| PUT    | `/api/works/:id`| Update a work, append new images, or remove existing gallery images  |
+| DELETE | `/api/works/:id`| Remove a work and all stored images                                  |
+
+When updating works you can send a `removeImages` array (JSON string or repeated fields)
+with the public image paths to delete from the gallery.
+
+## Data Storage
+
+For portability, the backend persists data to `data/database.json`. This file is created
+automatically on first run. The structure is intentionally simple so it can be replaced
+with a database layer (PostgreSQL, DynamoDB, etc.) without disrupting the route contracts.
+
+## Deployment Notes
+
+- The entry point is `src/server.js`.
+- Uploads live under `/uploads` and are served as static assets; ensure the directory is
+  writable on the deployment target.
+- Elastic Beanstalk Node.js environments will pick up the `start` script automatically.
+
+Feel free to extend the controllers to integrate with your preferred storage services or
+cloud-native pipelines as the project scales.

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "imagicity-backend",
+  "version": "1.0.0",
+  "description": "API backend for Imagicity web application.",
+  "type": "module",
+  "main": "src/server.js",
+  "scripts": {
+    "dev": "node --env-file=.env src/server.js",
+    "start": "node src/server.js",
+    "lint": "eslint ."
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.19.2",
+    "fs-extra": "^11.2.0",
+    "helmet": "^7.1.0",
+    "joi": "^17.12.1",
+    "morgan": "^1.10.0",
+    "multer": "^1.4.5-lts.1",
+    "nanoid": "^4.0.2"
+  },
+  "devDependencies": {
+    "eslint": "^8.56.0",
+    "eslint-config-prettier": "^9.1.0"
+  }
+}

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -1,0 +1,56 @@
+import express from 'express';
+import helmet from 'helmet';
+import cors from 'cors';
+import morgan from 'morgan';
+import multer from 'multer';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import blogsRouter from './routes/blogs.js';
+import servicesRouter from './routes/services.js';
+import worksRouter from './routes/works.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const app = express();
+
+app.use(helmet());
+app.use(cors({ origin: '*' }));
+app.use(express.json({ limit: '10mb' }));
+app.use(express.urlencoded({ extended: true }));
+app.use(morgan('dev'));
+
+const uploadsPath = path.join(__dirname, '..', 'uploads');
+app.use('/uploads', express.static(uploadsPath));
+
+app.get('/health', (_req, res) => {
+  res.json({ status: 'ok' });
+});
+
+app.use('/api/blogs', blogsRouter);
+app.use('/api/services', servicesRouter);
+app.use('/api/works', worksRouter);
+
+app.use((req, res) => {
+  res.status(404).json({ message: 'Not found' });
+});
+
+app.use((err, _req, res, _next) => {
+  // eslint-disable-next-line no-console
+  console.error(err);
+
+  if (err instanceof multer.MulterError) {
+    res.status(400).json({
+      message: err.message,
+    });
+    return;
+  }
+
+  res.status(err.status || 500).json({
+    message: err.message || 'Internal Server Error',
+    details: err.details || undefined,
+  });
+});
+
+export default app;

--- a/backend/src/controllers/blogsController.js
+++ b/backend/src/controllers/blogsController.js
@@ -1,0 +1,117 @@
+import path from 'node:path';
+import fs from 'fs-extra';
+import { nanoid } from 'nanoid';
+
+import DataStore from '../storage/dataStore.js';
+
+const COLLECTION = 'blogs';
+const uploadsRoot = path.join(process.cwd(), 'uploads', 'blogs');
+
+function withPublicImagePath(filename) {
+  return filename ? `/uploads/blogs/${filename}` : null;
+}
+
+export async function listBlogs(_req, res) {
+  const blogs = await DataStore.getCollection(COLLECTION);
+  res.json(blogs);
+}
+
+export async function getBlog(req, res, next) {
+  try {
+    const blogs = await DataStore.getCollection(COLLECTION);
+    const blog = blogs.find((item) => item.id === req.params.id);
+
+    if (!blog) {
+      res.status(404).json({ message: 'Blog not found' });
+      return;
+    }
+
+    res.json(blog);
+  } catch (error) {
+    next(error);
+  }
+}
+
+export async function createBlog(req, res, next) {
+  try {
+    const id = nanoid();
+    const timestamp = new Date().toISOString();
+    const filename = req.file?.filename ?? null;
+
+    const blog = {
+      id,
+      title: req.body.title,
+      excerpt: req.body.excerpt,
+      content: req.body.content,
+      image: withPublicImagePath(filename),
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    };
+
+    await DataStore.appendToCollection(COLLECTION, blog);
+
+    res.status(201).json(blog);
+  } catch (error) {
+    next(error);
+  }
+}
+
+export async function updateBlog(req, res, next) {
+  try {
+    const blogs = await DataStore.getCollection(COLLECTION);
+    const blogIndex = blogs.findIndex((item) => item.id === req.params.id);
+
+    if (blogIndex === -1) {
+      res.status(404).json({ message: 'Blog not found' });
+      return;
+    }
+
+    const existing = blogs[blogIndex];
+    let imagePath = existing.image;
+
+    if (req.file?.filename) {
+      imagePath = withPublicImagePath(req.file.filename);
+      if (existing.image) {
+        const previousFilename = path.basename(existing.image);
+        await fs.remove(path.join(uploadsRoot, previousFilename));
+      }
+    }
+
+    const updated = {
+      ...existing,
+      ...req.body,
+      image: imagePath,
+      updatedAt: new Date().toISOString(),
+    };
+
+    blogs[blogIndex] = updated;
+    await DataStore.saveCollection(COLLECTION, blogs);
+
+    res.json(updated);
+  } catch (error) {
+    next(error);
+  }
+}
+
+export async function deleteBlog(req, res, next) {
+  try {
+    const blogs = await DataStore.getCollection(COLLECTION);
+    const blogIndex = blogs.findIndex((item) => item.id === req.params.id);
+
+    if (blogIndex === -1) {
+      res.status(404).json({ message: 'Blog not found' });
+      return;
+    }
+
+    const [removed] = blogs.splice(blogIndex, 1);
+    if (removed.image) {
+      const filename = path.basename(removed.image);
+      await fs.remove(path.join(uploadsRoot, filename));
+    }
+
+    await DataStore.saveCollection(COLLECTION, blogs);
+    res.status(204).send();
+  } catch (error) {
+    next(error);
+  }
+}

--- a/backend/src/controllers/servicesController.js
+++ b/backend/src/controllers/servicesController.js
@@ -1,0 +1,83 @@
+import { nanoid } from 'nanoid';
+
+import DataStore from '../storage/dataStore.js';
+
+const COLLECTION = 'services';
+
+export async function listServices(_req, res) {
+  const services = await DataStore.getCollection(COLLECTION);
+  res.json(services);
+}
+
+export async function getService(req, res) {
+  const services = await DataStore.getCollection(COLLECTION);
+  const service = services.find((item) => item.id === req.params.id);
+
+  if (!service) {
+    res.status(404).json({ message: 'Service not found' });
+    return;
+  }
+
+  res.json(service);
+}
+
+export async function createService(req, res, next) {
+  try {
+    const service = {
+      id: nanoid(),
+      name: req.body.name,
+      summary: req.body.summary,
+      description: req.body.description,
+      highlight: req.body.highlight ?? null,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+
+    await DataStore.appendToCollection(COLLECTION, service);
+    res.status(201).json(service);
+  } catch (error) {
+    next(error);
+  }
+}
+
+export async function updateService(req, res, next) {
+  try {
+    const services = await DataStore.getCollection(COLLECTION);
+    const index = services.findIndex((item) => item.id === req.params.id);
+
+    if (index === -1) {
+      res.status(404).json({ message: 'Service not found' });
+      return;
+    }
+
+    const updated = {
+      ...services[index],
+      ...req.body,
+      updatedAt: new Date().toISOString(),
+    };
+
+    services[index] = updated;
+    await DataStore.saveCollection(COLLECTION, services);
+    res.json(updated);
+  } catch (error) {
+    next(error);
+  }
+}
+
+export async function deleteService(req, res, next) {
+  try {
+    const services = await DataStore.getCollection(COLLECTION);
+    const index = services.findIndex((item) => item.id === req.params.id);
+
+    if (index === -1) {
+      res.status(404).json({ message: 'Service not found' });
+      return;
+    }
+
+    services.splice(index, 1);
+    await DataStore.saveCollection(COLLECTION, services);
+    res.status(204).send();
+  } catch (error) {
+    next(error);
+  }
+}

--- a/backend/src/controllers/worksController.js
+++ b/backend/src/controllers/worksController.js
@@ -1,0 +1,132 @@
+import path from 'node:path';
+import fs from 'fs-extra';
+import { nanoid } from 'nanoid';
+
+import DataStore from '../storage/dataStore.js';
+import { normalizeRemoveList, normalizeTags } from '../utils/normalizers.js';
+
+const COLLECTION = 'works';
+const uploadsRoot = path.join(process.cwd(), 'uploads', 'works');
+
+function toPublicPaths(files = []) {
+  return files.map((file) => `/uploads/works/${file}`);
+}
+
+export async function listWorks(_req, res) {
+  const works = await DataStore.getCollection(COLLECTION);
+  res.json(works);
+}
+
+export async function getWork(req, res) {
+  const works = await DataStore.getCollection(COLLECTION);
+  const work = works.find((item) => item.id === req.params.id);
+
+  if (!work) {
+    res.status(404).json({ message: 'Work not found' });
+    return;
+  }
+
+  res.json(work);
+}
+
+export async function createWork(req, res, next) {
+  try {
+    const id = nanoid();
+    const images = toPublicPaths(req.files?.map((file) => file.filename) ?? []);
+    const timestamp = new Date().toISOString();
+
+    const work = {
+      id,
+      title: req.body.title,
+      client: req.body.client ?? null,
+      summary: req.body.summary,
+      description: req.body.description,
+      tags: normalizeTags(req.body.tags),
+      images,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    };
+
+    await DataStore.appendToCollection(COLLECTION, work);
+    res.status(201).json(work);
+  } catch (error) {
+    next(error);
+  }
+}
+
+export async function updateWork(req, res, next) {
+  try {
+    const works = await DataStore.getCollection(COLLECTION);
+    const index = works.findIndex((item) => item.id === req.params.id);
+
+    if (index === -1) {
+      res.status(404).json({ message: 'Work not found' });
+      return;
+    }
+
+    const existing = works[index];
+    let images = existing.images ?? [];
+
+    if (req.files?.length) {
+      const newPublicPaths = toPublicPaths(req.files.map((file) => file.filename));
+      images = [...images, ...newPublicPaths];
+    }
+
+    const removeList = normalizeRemoveList(req.body.removeImages);
+    if (removeList.length) {
+      const removeSet = new Set(removeList);
+      const remaining = [];
+      for (const image of images) {
+        if (removeSet.has(image)) {
+          const filename = path.basename(image);
+          await fs.remove(path.join(uploadsRoot, filename));
+        } else {
+          remaining.push(image);
+        }
+      }
+      images = remaining;
+    }
+
+    const hasTags = Object.prototype.hasOwnProperty.call(req.body, 'tags');
+    const updated = {
+      ...existing,
+      title: req.body.title ?? existing.title,
+      client: req.body.client ?? existing.client,
+      summary: req.body.summary ?? existing.summary,
+      description: req.body.description ?? existing.description,
+      tags: hasTags ? normalizeTags(req.body.tags) : existing.tags,
+      images,
+      updatedAt: new Date().toISOString(),
+    };
+
+    works[index] = updated;
+    await DataStore.saveCollection(COLLECTION, works);
+    res.json(updated);
+  } catch (error) {
+    next(error);
+  }
+}
+
+export async function deleteWork(req, res, next) {
+  try {
+    const works = await DataStore.getCollection(COLLECTION);
+    const index = works.findIndex((item) => item.id === req.params.id);
+
+    if (index === -1) {
+      res.status(404).json({ message: 'Work not found' });
+      return;
+    }
+
+    const [removed] = works.splice(index, 1);
+
+    for (const image of removed.images ?? []) {
+      const filename = path.basename(image);
+      await fs.remove(path.join(uploadsRoot, filename));
+    }
+
+    await DataStore.saveCollection(COLLECTION, works);
+    res.status(204).send();
+  } catch (error) {
+    next(error);
+  }
+}

--- a/backend/src/middleware/cleanupUploads.js
+++ b/backend/src/middleware/cleanupUploads.js
@@ -1,0 +1,26 @@
+import path from 'node:path';
+import fs from 'fs-extra';
+
+export default async function cleanupUploads(req) {
+  const files = [];
+
+  if (req.file) {
+    files.push(req.file);
+  }
+
+  if (Array.isArray(req.files)) {
+    files.push(...req.files);
+  } else if (req.files && typeof req.files === 'object') {
+    for (const value of Object.values(req.files)) {
+      if (Array.isArray(value)) {
+        files.push(...value);
+      } else if (value) {
+        files.push(value);
+      }
+    }
+  }
+
+  await Promise.all(
+    files.map((file) => fs.remove(path.join(file.destination, file.filename)))
+  );
+}

--- a/backend/src/middleware/upload.js
+++ b/backend/src/middleware/upload.js
@@ -1,0 +1,47 @@
+import multer from 'multer';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+function createStorage(folder) {
+  return multer.diskStorage({
+    destination: (_req, _file, cb) => {
+      cb(null, path.join(__dirname, '..', '..', 'uploads', folder));
+    },
+    filename: (_req, file, cb) => {
+      const uniqueSuffix = `${Date.now()}-${Math.round(Math.random() * 1e9)}`;
+      const ext = path.extname(file.originalname);
+      cb(null, `${file.fieldname}-${uniqueSuffix}${ext}`);
+    },
+  });
+}
+
+export function blogImageUpload() {
+  return multer({
+    storage: createStorage('blogs'),
+    fileFilter: (_req, file, cb) => {
+      if (!file.mimetype.startsWith('image/')) {
+        cb(new Error('Only image uploads are allowed'));
+        return;
+      }
+      cb(null, true);
+    },
+    limits: { fileSize: 5 * 1024 * 1024 },
+  });
+}
+
+export function workImagesUpload() {
+  return multer({
+    storage: createStorage('works'),
+    fileFilter: (_req, file, cb) => {
+      if (!file.mimetype.startsWith('image/')) {
+        cb(new Error('Only image uploads are allowed'));
+        return;
+      }
+      cb(null, true);
+    },
+    limits: { fileSize: 8 * 1024 * 1024 },
+  });
+}

--- a/backend/src/middleware/validate.js
+++ b/backend/src/middleware/validate.js
@@ -1,0 +1,28 @@
+export default function validateBody(
+  schema,
+  { allowUnknown = false, onError } = {}
+) {
+  return (req, _res, next) => {
+    const { error, value } = schema.validate(req.body, {
+      abortEarly: false,
+      allowUnknown,
+      stripUnknown: true,
+    });
+
+    if (error) {
+      error.status = 400;
+      error.details = error.details?.map((detail) => detail.message);
+      if (typeof onError === 'function') {
+        Promise.resolve(onError(req))
+          .catch(() => {})
+          .finally(() => next(error));
+        return;
+      }
+      next(error);
+      return;
+    }
+
+    req.body = value;
+    next();
+  };
+}

--- a/backend/src/routes/blogs.js
+++ b/backend/src/routes/blogs.js
@@ -1,0 +1,41 @@
+import { Router } from 'express';
+
+import {
+  createBlog,
+  deleteBlog,
+  getBlog,
+  listBlogs,
+  updateBlog,
+} from '../controllers/blogsController.js';
+import validateBody from '../middleware/validate.js';
+import cleanupUploads from '../middleware/cleanupUploads.js';
+import { blogImageUpload } from '../middleware/upload.js';
+import { createBlogSchema, updateBlogSchema } from '../validators/blogValidator.js';
+
+const router = Router();
+const upload = blogImageUpload();
+
+router.get('/', listBlogs);
+router.get('/:id', getBlog);
+
+router.post(
+  '/',
+  upload.single('image'),
+  validateBody(createBlogSchema, {
+    onError: (req) => cleanupUploads(req),
+  }),
+  createBlog
+);
+
+router.put(
+  '/:id',
+  upload.single('image'),
+  validateBody(updateBlogSchema, {
+    onError: (req) => cleanupUploads(req),
+  }),
+  updateBlog
+);
+
+router.delete('/:id', deleteBlog);
+
+export default router;

--- a/backend/src/routes/services.js
+++ b/backend/src/routes/services.js
@@ -1,0 +1,31 @@
+import { Router } from 'express';
+
+import {
+  createService,
+  deleteService,
+  getService,
+  listServices,
+  updateService,
+} from '../controllers/servicesController.js';
+import validateBody from '../middleware/validate.js';
+import {
+  createServiceSchema,
+  updateServiceSchema,
+} from '../validators/serviceValidator.js';
+
+const router = Router();
+
+router.get('/', listServices);
+router.get('/:id', getService);
+
+router.post('/', validateBody(createServiceSchema), createService);
+
+router.put(
+  '/:id',
+  validateBody(updateServiceSchema, { allowUnknown: true }),
+  updateService
+);
+
+router.delete('/:id', deleteService);
+
+export default router;

--- a/backend/src/routes/works.js
+++ b/backend/src/routes/works.js
@@ -1,0 +1,42 @@
+import { Router } from 'express';
+
+import {
+  createWork,
+  deleteWork,
+  getWork,
+  listWorks,
+  updateWork,
+} from '../controllers/worksController.js';
+import cleanupUploads from '../middleware/cleanupUploads.js';
+import validateBody from '../middleware/validate.js';
+import { workImagesUpload } from '../middleware/upload.js';
+import { createWorkSchema, updateWorkSchema } from '../validators/workValidator.js';
+
+const router = Router();
+const upload = workImagesUpload();
+
+router.get('/', listWorks);
+router.get('/:id', getWork);
+
+router.post(
+  '/',
+  upload.array('images', 10),
+  validateBody(createWorkSchema, {
+    onError: (req) => cleanupUploads(req),
+  }),
+  createWork
+);
+
+router.put(
+  '/:id',
+  upload.array('images', 10),
+  validateBody(updateWorkSchema, {
+    allowUnknown: true,
+    onError: (req) => cleanupUploads(req),
+  }),
+  updateWork
+);
+
+router.delete('/:id', deleteWork);
+
+export default router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -1,0 +1,32 @@
+import http from 'node:http';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import fs from 'fs-extra';
+
+import app from './app.js';
+
+const PORT = process.env.PORT || 5000;
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+async function ensureDirectories() {
+  const basePath = path.join(__dirname, '..');
+  await fs.ensureDir(path.join(basePath, 'uploads', 'blogs'));
+  await fs.ensureDir(path.join(basePath, 'uploads', 'works'));
+  await fs.ensureDir(path.join(basePath, 'data'));
+}
+
+async function startServer() {
+  await ensureDirectories();
+  const server = http.createServer(app);
+  server.listen(PORT, () => {
+    // eslint-disable-next-line no-console
+    console.log(`API server listening on port ${PORT}`);
+  });
+}
+
+startServer().catch((error) => {
+  // eslint-disable-next-line no-console
+  console.error('Failed to start server', error);
+  process.exit(1);
+});

--- a/backend/src/storage/dataStore.js
+++ b/backend/src/storage/dataStore.js
@@ -1,0 +1,45 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import fs from 'fs-extra';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const DATA_FILE = path.join(__dirname, '..', '..', 'data', 'database.json');
+
+async function readData() {
+  try {
+    const raw = await fs.readFile(DATA_FILE, 'utf-8');
+    return JSON.parse(raw);
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      return { blogs: [], services: [], works: [] };
+    }
+    throw error;
+  }
+}
+
+async function writeData(data) {
+  await fs.outputJson(DATA_FILE, data, { spaces: 2 });
+}
+
+export default class DataStore {
+  static async getCollection(key) {
+    const data = await readData();
+    return data[key] || [];
+  }
+
+  static async saveCollection(key, collection) {
+    const data = await readData();
+    data[key] = collection;
+    await writeData(data);
+    return data[key];
+  }
+
+  static async appendToCollection(key, item) {
+    const collection = await DataStore.getCollection(key);
+    collection.push(item);
+    await DataStore.saveCollection(key, collection);
+    return item;
+  }
+}

--- a/backend/src/utils/normalizers.js
+++ b/backend/src/utils/normalizers.js
@@ -1,0 +1,70 @@
+export function normalizeTags(raw) {
+  if (raw === undefined || raw === null) {
+    return [];
+  }
+
+  if (Array.isArray(raw)) {
+    return raw
+      .map((item) => String(item).trim())
+      .filter(Boolean);
+  }
+
+  if (typeof raw === 'string') {
+    const trimmed = raw.trim();
+
+    if (!trimmed) {
+      return [];
+    }
+
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (Array.isArray(parsed)) {
+        return parsed
+          .map((item) => String(item).trim())
+          .filter(Boolean);
+      }
+    } catch (error) {
+      // fall back to comma separated parsing
+    }
+
+    return trimmed
+      .split(',')
+      .map((item) => item.trim())
+      .filter(Boolean);
+  }
+
+  return [];
+}
+
+export function normalizeRemoveList(raw) {
+  if (raw === undefined || raw === null) {
+    return [];
+  }
+
+  if (Array.isArray(raw)) {
+    return raw
+      .map((item) => String(item).trim())
+      .filter(Boolean);
+  }
+
+  if (typeof raw === 'string') {
+    const trimmed = raw.trim();
+
+    if (!trimmed) {
+      return [];
+    }
+
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (Array.isArray(parsed)) {
+        return parsed.map((item) => String(item).trim()).filter(Boolean);
+      }
+    } catch (error) {
+      // ignore parsing failure
+    }
+
+    return [trimmed];
+  }
+
+  return [];
+}

--- a/backend/src/validators/blogValidator.js
+++ b/backend/src/validators/blogValidator.js
@@ -1,0 +1,12 @@
+import Joi from 'joi';
+
+export const createBlogSchema = Joi.object({
+  title: Joi.string().min(3).max(120).required(),
+  excerpt: Joi.string().min(10).max(280).required(),
+  content: Joi.string().min(20).required()
+});
+
+export const updateBlogSchema = createBlogSchema.fork(
+  ['title', 'excerpt', 'content'],
+  (schema) => schema.optional()
+);

--- a/backend/src/validators/serviceValidator.js
+++ b/backend/src/validators/serviceValidator.js
@@ -1,0 +1,13 @@
+import Joi from 'joi';
+
+export const createServiceSchema = Joi.object({
+  name: Joi.string().min(3).max(100).required(),
+  summary: Joi.string().min(10).max(200).required(),
+  description: Joi.string().min(20).required(),
+  highlight: Joi.string().min(3).max(60).optional()
+});
+
+export const updateServiceSchema = createServiceSchema.fork(
+  ['name', 'summary', 'description', 'highlight'],
+  (schema) => schema.optional()
+);

--- a/backend/src/validators/workValidator.js
+++ b/backend/src/validators/workValidator.js
@@ -1,0 +1,45 @@
+import Joi from 'joi';
+
+import { normalizeRemoveList, normalizeTags } from '../utils/normalizers.js';
+
+const tagSchema = Joi.string().min(2).max(40);
+
+function tagsField() {
+  return Joi.any()
+    .default([])
+    .custom((value, helpers) => {
+      const parsed = normalizeTags(value);
+      for (const tag of parsed) {
+        const { error } = tagSchema.validate(tag);
+        if (error) {
+          return helpers.error('any.invalid', { message: error.message });
+        }
+      }
+      return parsed;
+    }, 'tags normalization');
+}
+
+const removeImagesField = Joi.any().custom((value, helpers) => {
+  const parsed = normalizeRemoveList(value);
+  for (const item of parsed) {
+    if (typeof item !== 'string' || !item.trim()) {
+      return helpers.error('any.invalid', { message: 'Invalid image reference' });
+    }
+  }
+  return parsed;
+}, 'remove images normalization');
+
+export const createWorkSchema = Joi.object({
+  title: Joi.string().min(3).max(120).required(),
+  client: Joi.string().min(2).max(100).optional(),
+  summary: Joi.string().min(10).max(250).required(),
+  description: Joi.string().min(20).required(),
+  tags: tagsField(),
+});
+
+export const updateWorkSchema = createWorkSchema.fork(
+  ['title', 'client', 'summary', 'description', 'tags'],
+  (schema) => schema.optional()
+).append({
+  removeImages: removeImagesField.optional(),
+});

--- a/src/components/BlogCarousel.css
+++ b/src/components/BlogCarousel.css
@@ -7,10 +7,10 @@
 
 .blog-carousel__viewport {
   overflow: hidden;
-  border-radius: 26px;
-  border: 1px solid rgba(61, 218, 215, 0.15);
-  background: rgba(255, 255, 255, 0.9);
-  box-shadow: inset 0 0 0 1px rgba(248, 250, 180, 0.14);
+  border-radius: 18px;
+  border: 1px solid rgba(255, 0, 92, 0.22);
+  background: var(--surface-strong);
+  box-shadow: inset 0 0 0 1px rgba(255, 246, 0, 0.12);
   cursor: grab;
 }
 
@@ -26,15 +26,18 @@
 }
 
 .blog-card {
-  min-width: min(320px, 80vw);
+  width: clamp(260px, 28vw, 320px);
+  min-height: clamp(260px, 28vw, 320px);
   scroll-snap-align: start;
   flex: 0 0 auto;
   padding: clamp(1.6rem, 4vw, 2.2rem);
-  border-radius: 20px;
-  background: rgba(255, 255, 255, 0.95);
-  border: 1px solid rgba(248, 250, 180, 0.3);
-  box-shadow: 0 24px 36px rgba(15, 39, 37, 0.08);
+  border-radius: 16px;
+  background: rgba(16, 16, 16, 0.92);
+  border: 1px solid rgba(255, 0, 92, 0.2);
+  box-shadow: 0 24px 36px rgba(0, 0, 0, 0.55);
   display: grid;
+  grid-template-rows: auto 1fr auto;
+  align-content: start;
   gap: 0.85rem;
 }
 
@@ -45,13 +48,13 @@
 
 .blog-card p {
   margin: 0;
-  color: rgba(15, 39, 37, 0.72);
+  color: rgba(246, 239, 210, 0.78);
 }
 
 .blog-card__link {
   font-weight: 600;
   font-size: 0.95rem;
-  color: var(--accent-rose);
+  color: var(--accent-butter);
 }
 
 .blog-carousel__control {
@@ -59,24 +62,24 @@
   height: 48px;
   border-radius: 50%;
   border: none;
-  background: radial-gradient(circle at 30% 30%, rgba(61, 218, 215, 0.28), rgba(240, 135, 135, 0.35));
-  color: var(--ink);
+  background: var(--accent-rose);
+  color: #0a0a0a;
   font-size: 1.8rem;
   line-height: 1;
   display: grid;
   place-items: center;
   cursor: pointer;
   transition: transform 240ms ease, box-shadow 240ms ease;
-  box-shadow: 0 14px 24px rgba(240, 135, 135, 0.26);
+  box-shadow: 0 14px 24px rgba(247, 56, 89, 0.35);
 }
 
 .blog-carousel__control:hover {
   transform: translateY(-3px);
-  box-shadow: 0 18px 32px rgba(240, 135, 135, 0.34);
+  box-shadow: 0 18px 32px rgba(247, 56, 89, 0.45);
 }
 
 .blog-carousel__control:focus-visible {
-  outline: 2px solid var(--accent-aqua);
+  outline: 2px solid var(--accent-butter);
   outline-offset: 3px;
 }
 

--- a/src/components/LiquidBackground.css
+++ b/src/components/LiquidBackground.css
@@ -4,7 +4,7 @@
   overflow: hidden;
   pointer-events: none;
   z-index: 0;
-  background: #ffffff;
+  background: #000000;
   --pointer-x: 50%;
   --pointer-y: 50%;
 }
@@ -19,21 +19,21 @@
   filter: blur(100px);
   opacity: 0.8;
   transition: opacity 400ms ease;
-  mix-blend-mode: multiply;
+  mix-blend-mode: screen;
   animation: liquid-oscillate 18s ease-in-out infinite;
 }
 
 .liquid-ether__layer--a {
-  background: radial-gradient(circle at center, rgba(61, 218, 215, 0.32), transparent 65%);
+  background: radial-gradient(circle at center, rgba(255, 0, 92, 0.32), transparent 65%);
 }
 
 .liquid-ether__layer--b {
-  background: radial-gradient(circle at center, rgba(240, 135, 135, 0.25), transparent 60%);
+  background: radial-gradient(circle at center, rgba(255, 246, 0, 0.24), transparent 60%);
   animation-delay: -6s;
 }
 
 .liquid-ether__layer--c {
-  background: radial-gradient(circle at center, rgba(248, 250, 180, 0.22), transparent 62%);
+  background: radial-gradient(circle at center, rgba(247, 56, 89, 0.26), transparent 62%);
   animation-delay: -12s;
 }
 

--- a/src/components/RotatingText.css
+++ b/src/components/RotatingText.css
@@ -5,7 +5,7 @@
   justify-items: center;
   min-width: 14ch;
   font-weight: 600;
-  color: #0f2725;
+  color: var(--accent-butter);
   text-transform: lowercase;
 }
 
@@ -17,8 +17,8 @@
   width: 100%;
   padding: 0.2rem 0.6rem 0.3rem;
   border-radius: 0.75rem;
-  background: rgba(61, 218, 215, 0.14);
-  color: #0f2725;
+  background: rgba(255, 246, 0, 0.65);
+  color: #ffffff;
   opacity: 0;
   transform: translateY(12px) rotate(2deg);
   filter: blur(6px);
@@ -29,7 +29,7 @@
   opacity: 1;
   transform: translateY(0) rotate(0deg);
   filter: blur(0);
-  background: rgba(240, 135, 135, 0.2);
+  background: var(--accent-aqua);
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/components/ScrollStack.css
+++ b/src/components/ScrollStack.css
@@ -9,7 +9,7 @@
   content: '';
   position: absolute;
   inset: 0;
-  background: linear-gradient(180deg, rgba(248, 250, 180, 0.16), transparent 35%, transparent 65%, rgba(61, 218, 215, 0.1));
+  background: linear-gradient(180deg, rgba(255, 0, 92, 0.08), transparent 35%, transparent 65%, rgba(255, 246, 0, 0.08));
   pointer-events: none;
   z-index: -2;
 }
@@ -19,9 +19,9 @@
   top: calc(clamp(5rem, 18vh, 8rem) + var(--stack-index, 0) * clamp(0.8rem, 2vw, 1.4rem));
   padding: clamp(2rem, 5vw, 2.8rem);
   border-radius: 26px;
-  border: 1px solid rgba(61, 218, 215, 0.2);
-  background: rgba(255, 255, 255, 0.95);
-  box-shadow: 0 28px 60px rgba(15, 39, 37, 0.12);
+  border: 1px solid rgba(255, 0, 92, 0.26);
+  background-color: rgba(8, 8, 8, 0.98);
+  box-shadow: 0 28px 60px rgba(0, 0, 0, 0.68);
   display: grid;
   gap: 1.1rem;
   overflow: hidden;
@@ -54,18 +54,18 @@
   font-weight: 600;
   letter-spacing: 0.18em;
   text-transform: uppercase;
-  color: rgba(15, 39, 37, 0.8);
-  background: linear-gradient(135deg, rgba(61, 218, 215, 0.18), rgba(240, 135, 135, 0.25));
-  box-shadow: inset 0 0 0 1px rgba(61, 218, 215, 0.2);
+  color: #080808;
+  background-color: #fff600;
+  box-shadow: inset 0 0 0 1px rgba(255, 0, 92, 0.32);
 }
 
 .scroll-stack__titles p {
-  color: rgba(15, 39, 37, 0.65);
+  color: rgba(246, 239, 210, 0.7);
   font-size: 0.95rem;
 }
 
 .scroll-stack__description {
-  color: rgba(15, 39, 37, 0.72);
+  color: rgba(246, 239, 210, 0.78);
   font-size: 1.02rem;
 }
 
@@ -74,16 +74,16 @@
   padding-left: 1.1rem;
   display: grid;
   gap: 0.45rem;
-  color: rgba(15, 39, 37, 0.7);
+  color: rgba(246, 239, 210, 0.75);
   font-size: 0.95rem;
 }
 
 .scroll-stack__glow {
   position: absolute;
   inset: -35% -40% 40% -40%;
-  background: radial-gradient(circle at 20% 20%, rgba(61, 218, 215, 0.32), transparent 65%),
-    radial-gradient(circle at 80% 80%, rgba(240, 135, 135, 0.35), transparent 65%),
-    radial-gradient(circle at 50% 0%, rgba(255, 199, 167, 0.4), transparent 70%);
+  background: radial-gradient(circle at 20% 20%, rgba(255, 0, 92, 0.35), transparent 65%),
+    radial-gradient(circle at 80% 80%, rgba(255, 246, 0, 0.25), transparent 70%),
+    radial-gradient(circle at 50% 0%, rgba(247, 56, 89, 0.4), transparent 70%);
   filter: blur(70px);
   opacity: 0.9;
   z-index: -1;

--- a/src/index.css
+++ b/src/index.css
@@ -2,16 +2,19 @@
 
 :root {
   font-family: 'Space Grotesk', 'Plus Jakarta Sans', 'Segoe UI', sans-serif;
-  color: #152221;
-  background-color: #ffffff;
+  color: #f6efd2;
+  background-color: #000000;
   line-height: 1.6;
-  --accent-aqua: #3ddad7;
-  --accent-rose: #f08787;
-  --accent-peach: #ffc7a7;
-  --accent-butter: #f8fab4;
-  --ink: #0f2725;
-  --muted: #5f7573;
-  --border: #e4eeed;
+  --accent-aqua: #ff005c;
+  --accent-rose: #f73859;
+  --accent-peach: #e43636;
+  --accent-butter: #fff600;
+  --ink: #f6efd2;
+  --muted: rgba(230, 221, 180, 0.7);
+  --border: rgba(246, 239, 210, 0.16);
+  --surface: rgba(12, 12, 12, 0.86);
+  --surface-strong: rgba(20, 20, 20, 0.94);
+  --shadow: 0 40px 80px rgba(0, 0, 0, 0.65);
   --sticky-header-offset: clamp(6.5rem, 14vw, 9rem);
 }
 
@@ -22,7 +25,7 @@
 body {
   margin: 0;
   min-height: 100vh;
-  background: #ffffff;
+  background: #000000;
   color: var(--ink);
   -webkit-font-smoothing: antialiased;
 }
@@ -37,7 +40,7 @@ a {
 }
 
 a:focus-visible {
-  outline: 2px solid var(--accent-aqua);
+  outline: 2px solid var(--accent-butter);
   outline-offset: 2px;
 }
 
@@ -53,8 +56,9 @@ a:focus-visible {
   position: sticky;
   top: 0;
   z-index: 3;
-  background: #ffffff;
+  background: var(--surface);
   border-bottom: 1px solid var(--border);
+  backdrop-filter: blur(14px);
 }
 
 .page__header-inner {
@@ -72,7 +76,7 @@ a:focus-visible {
   font-weight: 600;
   letter-spacing: 0.18em;
   text-transform: uppercase;
-  color: var(--muted);
+  color: var(--accent-butter);
 }
 
 .page__nav {
@@ -87,7 +91,7 @@ a:focus-visible {
   font-weight: 500;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: var(--ink);
+  color: rgba(246, 239, 210, 0.82);
   transition: color 320ms ease;
 }
 
@@ -97,8 +101,8 @@ a:focus-visible {
   inset: auto 0 -0.55rem 0;
   height: 0.3rem;
   border-radius: 999px;
-  background: radial-gradient(circle at 20% 20%, rgba(61, 218, 215, 0.45), transparent 70%),
-    radial-gradient(circle at 80% 80%, rgba(240, 135, 135, 0.4), transparent 70%);
+  background: radial-gradient(circle at 20% 20%, rgba(255, 246, 0, 0.6), transparent 70%),
+    radial-gradient(circle at 80% 80%, rgba(255, 0, 92, 0.45), transparent 70%);
   opacity: 0;
   transform: scaleX(0.4);
   transition: opacity 320ms ease, transform 320ms ease;
@@ -106,7 +110,7 @@ a:focus-visible {
 
 .page__nav a:hover,
 .page__nav a:focus-visible {
-  color: var(--muted);
+  color: var(--accent-butter);
 }
 
 .page__nav a:hover::after,
@@ -145,7 +149,7 @@ a:focus-visible {
   font-size: 0.85rem;
   letter-spacing: 0.32em;
   text-transform: uppercase;
-  color: rgba(15, 39, 37, 0.58);
+  color: rgba(246, 239, 210, 0.58);
 }
 
 .section__title {
@@ -158,7 +162,7 @@ a:focus-visible {
 .section__subtitle {
   margin: 0;
   font-family: 'Plus Jakarta Sans', 'Space Grotesk', sans-serif;
-  color: rgba(15, 39, 37, 0.68);
+  color: rgba(246, 239, 210, 0.7);
 }
 
 .services__manifesto {
@@ -166,7 +170,7 @@ a:focus-visible {
   max-width: 820px;
   font-size: clamp(1.05rem, 2.6vw, 1.2rem);
   line-height: 1.65;
-  color: rgba(15, 39, 37, 0.78);
+  color: rgba(246, 239, 210, 0.82);
   font-weight: 500;
   letter-spacing: -0.01em;
 }
@@ -176,7 +180,7 @@ a:focus-visible {
   max-width: 780px;
   font-size: clamp(1.02rem, 2.4vw, 1.18rem);
   line-height: 1.6;
-  color: rgba(15, 39, 37, 0.78);
+  color: rgba(246, 239, 210, 0.82);
 }
 
 .hero {
@@ -187,12 +191,12 @@ a:focus-visible {
 .hero__card {
   position: relative;
   width: 100%;
-  max-width: clamp(520px, 60vw, 680px);
-  padding: clamp(2.6rem, 6vw, 4rem);
+  max-width: clamp(560px, 64vw, 760px);
+  padding: clamp(3rem, 7vw, 4.8rem);
   border-radius: 28px;
-  background: rgba(255, 255, 255, 0.88);
-  border: 1px solid rgba(61, 218, 215, 0.25);
-  box-shadow: 0 40px 80px rgba(15, 39, 37, 0.08);
+  background: linear-gradient(140deg, rgba(255, 0, 92, 0.16), rgba(14, 14, 14, 0.92));
+  border: 1px solid rgba(255, 246, 0, 0.22);
+  box-shadow: var(--shadow);
   display: grid;
   gap: 1.5rem;
   text-align: center;
@@ -204,7 +208,7 @@ a:focus-visible {
   font-size: 0.95rem;
   letter-spacing: 0.28em;
   text-transform: uppercase;
-  color: rgba(15, 39, 37, 0.6);
+  color: rgba(255, 246, 0, 0.7);
 }
 
 .hero__heading {
@@ -224,7 +228,7 @@ a:focus-visible {
   margin: 0;
   font-family: 'Plus Jakarta Sans', 'Space Grotesk', sans-serif;
   font-size: 1rem;
-  color: rgba(15, 39, 37, 0.72);
+  color: rgba(246, 239, 210, 0.78);
   max-width: 34ch;
 }
 
@@ -232,7 +236,7 @@ a:focus-visible {
   display: grid;
   gap: 1.2rem;
   font-size: 1.05rem;
-  color: rgba(15, 39, 37, 0.8);
+  color: rgba(246, 239, 210, 0.82);
 }
 
 
@@ -240,9 +244,9 @@ a:focus-visible {
   position: relative;
   padding: clamp(1.8rem, 4vw, 2.4rem);
   border-radius: 22px;
-  border: 1px solid rgba(240, 135, 135, 0.25);
-  background: rgba(255, 255, 255, 0.92);
-  box-shadow: 0 28px 44px rgba(15, 39, 37, 0.08);
+  border: 1px solid rgba(255, 0, 92, 0.26);
+  background: linear-gradient(150deg, rgba(231, 54, 89, 0.16), rgba(16, 16, 16, 0.94));
+  box-shadow: 0 28px 44px rgba(0, 0, 0, 0.6);
   display: grid;
   gap: 0.8rem;
   transition: transform 360ms ease;
@@ -256,11 +260,12 @@ a:focus-visible {
   justify-self: flex-start;
   padding: 0.25rem 0.75rem;
   border-radius: 999px;
-  background: rgba(61, 218, 215, 0.16);
+  background-color: #fff600;
   font-size: 0.75rem;
   letter-spacing: 0.18em;
   text-transform: uppercase;
-  color: rgba(15, 39, 37, 0.65);
+  color: #080808;
+  box-shadow: inset 0 0 0 1px rgba(255, 0, 92, 0.22);
 }
 
 .contact__panel {
@@ -269,9 +274,9 @@ a:focus-visible {
   gap: clamp(2rem, 4vw, 3rem);
   padding: clamp(2.6rem, 6vw, 3.5rem);
   border-radius: 28px;
-  background: rgba(255, 255, 255, 0.92);
-  border: 1px solid rgba(61, 218, 215, 0.25);
-  box-shadow: 0 32px 60px rgba(15, 39, 37, 0.1);
+  background: var(--surface-strong);
+  border: 1px solid rgba(255, 0, 92, 0.24);
+  box-shadow: 0 32px 60px rgba(0, 0, 0, 0.65);
 }
 
 .contact__intro {
@@ -285,7 +290,7 @@ a:focus-visible {
   font-size: 0.85rem;
   letter-spacing: 0.28em;
   text-transform: uppercase;
-  color: rgba(15, 39, 37, 0.58);
+  color: rgba(255, 246, 0, 0.7);
 }
 
 .contact__title {
@@ -298,7 +303,7 @@ a:focus-visible {
   margin: 0;
   font-family: 'Plus Jakarta Sans', 'Space Grotesk', sans-serif;
   font-size: 1rem;
-  color: rgba(15, 39, 37, 0.68);
+  color: rgba(246, 239, 210, 0.72);
 }
 
 .contact__form {
@@ -310,7 +315,7 @@ a:focus-visible {
   font-size: 0.9rem;
   letter-spacing: 0.05em;
   text-transform: uppercase;
-  color: rgba(15, 39, 37, 0.6);
+  color: rgba(246, 239, 210, 0.65);
 }
 
 .contact__form input,
@@ -318,8 +323,8 @@ a:focus-visible {
   width: 100%;
   padding: 0.85rem 1rem;
   border-radius: 14px;
-  border: 1px solid rgba(21, 34, 33, 0.12);
-  background: rgba(248, 250, 180, 0.16);
+  border: 1px solid rgba(255, 246, 0, 0.18);
+  background: rgba(20, 20, 20, 0.8);
   font-family: inherit;
   font-size: 1rem;
   color: var(--ink);
@@ -329,8 +334,8 @@ a:focus-visible {
 .contact__form input:focus,
 .contact__form textarea:focus {
   outline: none;
-  border-color: rgba(61, 218, 215, 0.7);
-  box-shadow: 0 0 0 3px rgba(61, 218, 215, 0.18);
+  border-color: rgba(255, 0, 92, 0.7);
+  box-shadow: 0 0 0 3px rgba(255, 0, 92, 0.22);
 }
 
 .contact__form textarea {
@@ -348,17 +353,16 @@ a:focus-visible {
   font-weight: 600;
   letter-spacing: 0.12em;
   text-transform: uppercase;
-  color: #ffffff;
-  background: radial-gradient(circle at 20% 20%, var(--accent-aqua), rgba(61, 218, 215, 0.6)),
-    radial-gradient(circle at 80% 80%, var(--accent-rose), rgba(240, 135, 135, 0.7));
-  box-shadow: 0 18px 30px rgba(240, 135, 135, 0.32);
+  color: #080808;
+  background: var(--accent-butter);
+  box-shadow: 0 18px 30px rgba(255, 246, 0, 0.28);
   cursor: pointer;
   transition: transform 320ms ease, box-shadow 320ms ease;
 }
 
 .contact__submit:hover {
   transform: translateY(-4px);
-  box-shadow: 0 26px 44px rgba(240, 135, 135, 0.4);
+  box-shadow: 0 26px 44px rgba(255, 246, 0, 0.35);
 }
 
 @media (max-width: 720px) {
@@ -404,7 +408,7 @@ a:focus-visible {
   margin-top: auto;
   position: sticky;
   bottom: 0;
-  background: rgba(255, 255, 255, 0.98);
+  background: var(--surface);
   border-top: 1px solid var(--border);
   z-index: 2;
 }
@@ -425,7 +429,7 @@ a:focus-visible {
   font-size: 0.85rem;
   letter-spacing: 0.12em;
   text-transform: uppercase;
-  color: rgba(15, 39, 37, 0.58);
+  color: rgba(246, 239, 210, 0.58);
 }
 
 .page__footer-nav {
@@ -438,11 +442,11 @@ a:focus-visible {
 }
 
 .page__footer-nav a {
-  color: rgba(15, 39, 37, 0.68);
+  color: rgba(246, 239, 210, 0.7);
   transition: color 220ms ease;
 }
 
 .page__footer-nav a:hover,
 .page__footer-nav a:focus-visible {
-  color: var(--ink);
+  color: var(--accent-butter);
 }


### PR DESCRIPTION
## Summary
- add a standalone Express backend with blogs, services, and works modules backed by a JSON datastore
- implement image upload handling, validation, and CRUD controllers with reusable middleware
- document backend usage and deployment considerations in a dedicated README

## Testing
- npm install *(fails: registry access is restricted in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e26e093460832494d8a52d8f25549a